### PR TITLE
East Cascades dashboard

### DIFF
--- a/trails-viz-api/requirements.txt
+++ b/trails-viz-api/requirements.txt
@@ -1,4 +1,6 @@
-Flask==1.1.1
+Flask==2.1.0
+Werkzeug==2.0.0
+jinja2==3.0.3
 numpy==1.16.4
 pandas==0.25.1
 geopandas==0.4.1

--- a/trails-viz-api/trailsvizapi/config/app_config.py
+++ b/trails-viz-api/trailsvizapi/config/app_config.py
@@ -9,15 +9,16 @@ AUTH_BUCKET_NAME = 'recsetgo'
 PROJECT_NAMES = {
     'West Cascades': 'WestCascades',
     'Middle Fork': 'WestCascades_MiddleFork',
-    'Okanogan-Wenatchee Wilderness': 'OKW_WILD',
-    'Okanogan-Wenatchee General Forest': 'OKW_GFA',
+    'Okanogan-Wenatchee Wilderness (Archived)': 'OKW_WILD',
+    'Okanogan-Wenatchee General Forest (Archived)': 'OKW_GFA',
     'Northern New Mexico': 'NNM',
     'King County Parks': 'KingCo',
     'US National Forests': 'NationalForests',
     'Mount Baker-Snoqualmie Wilderness': 'MBS_WILD',
     'Mountain Loop': 'WestCascades_MtnLoop',
-    'South Mountain Loop': 'WestCascades_SMtnLoop'
+    'South Mountain Loop': 'WestCascades_SMtnLoop',
     # 'Mount Baker-Snoqualmie General Forest': 'MBS_GFA'
+    'East Cascades': 'EastCascades'
 }
 
 CENSUS_TRACT_STATES = {
@@ -29,8 +30,9 @@ CENSUS_TRACT_STATES = {
     'KingCo': ['53'],
     'MBS_WILD': ['53'],
     'WestCascades_MtnLoop': ['53'],
-    'WestCascades_SMtnLoop': ['53']
+    'WestCascades_SMtnLoop': ['53'],
     # 'MBS_GFA': ['53']
+    'EastCascades': ['53']
 }
 
 DATA_COLUMNS = {
@@ -43,6 +45,7 @@ DATA_COLUMNS = {
     'NationalForests': ['flickr', 'twitter', 'instag', 'alltrails'],
     'MBS_WILD': ['estimate', 'flickr', 'twitter', 'instag', 'wta', 'alltrails'],
     'WestCascades_MtnLoop': ['estimate', 'flickr', 'twitter', 'instag', 'alltrails', 'ebird', 'wta', 'onsite'],
-    'WestCascades_SMtnLoop': ['estimate', 'flickr', 'twitter', 'instag', 'alltrails', 'ebird', 'wta', 'onsite']
+    'WestCascades_SMtnLoop': ['estimate', 'flickr', 'twitter', 'instag', 'alltrails', 'ebird', 'wta', 'onsite'],
     # 'MBS_GFA': ['flickr', 'twitter', 'instag', 'wta', 'alltrails']
+    'EastCascades': ['estimate', 'flickr', 'twitter', 'alltrails', 'ebird', 'wta', 'onsite']
 }


### PR DESCRIPTION
Adding new EastCascades dashboard, plus adding the word "archived" to the OKW NVUM projects.

I think this is all that's required to kick the new data into a new dashboard instance, once[ `trails-viz-data` PR 40](https://github.com/OutdoorRD/trails-viz-data/pull/40) has been merged.