### PR TITLE
Coronado dashboard config!

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ $ npm run serve
 ```
 This will start the server on port 8080. Navigate to http://localhost:8080.
 
+Note: If you encounter `CORS` policy issues when viewing the dashboard on the development server, try different browsers. Firefox works, but Chrome and Safari may result in bugs.
+
 ## Build
 Front end and back end has must be built separately. Run the following commands form the root of the project - `trails-viz`
 ```shell script

--- a/trails-viz-api/trailsvizapi/config/app_config.py
+++ b/trails-viz-api/trailsvizapi/config/app_config.py
@@ -18,7 +18,8 @@ PROJECT_NAMES = {
     'Mountain Loop': 'WestCascades_MtnLoop',
     'South Mountain Loop': 'WestCascades_SMtnLoop',
     # 'Mount Baker-Snoqualmie General Forest': 'MBS_GFA'
-    'East Cascades': 'EastCascades'
+    'East Cascades': 'EastCascades',
+    'Coronado': 'Coronado'
 }
 
 CENSUS_TRACT_STATES = {
@@ -47,5 +48,6 @@ DATA_COLUMNS = {
     'WestCascades_MtnLoop': ['estimate', 'flickr', 'twitter', 'instag', 'alltrails', 'ebird', 'wta', 'onsite'],
     'WestCascades_SMtnLoop': ['estimate', 'flickr', 'twitter', 'instag', 'alltrails', 'ebird', 'wta', 'onsite'],
     # 'MBS_GFA': ['flickr', 'twitter', 'instag', 'wta', 'alltrails']
-    'EastCascades': ['estimate', 'flickr', 'twitter', 'alltrails', 'ebird', 'wta', 'onsite']
+    'EastCascades': ['estimate', 'flickr', 'twitter', 'alltrails', 'ebird', 'wta', 'onsite'],
+    'Coronado': ['estimate', 'flickr', 'twitter', 'alltrails', 'ebird', 'onsite']
 }


### PR DESCRIPTION
Adding new coronado dashboard specifications. I think that these are all the changes that we should need to add this dashboard.

Note that I did not include an entry for census_tract_states, since we don't have demographics data to display as part of this dashboard. Hopefully this won't break things... if it does, I think it would be ok to add a row and just point to one of the existing census states (either 53: WA or 35: NM), since neither will actually be displayed.

This PR is paired with [Coronado dashboard data PR](https://github.com/OutdoorRD/trails-viz-data/pull/43) in `trails-viz-data`