### PR TITLE
Add Reveal and remove Instagram from Westcascades dashboard

### DIFF
--- a/trails-viz-api/trailsvizapi/config/app_config.py
+++ b/trails-viz-api/trailsvizapi/config/app_config.py
@@ -38,7 +38,7 @@ CENSUS_TRACT_STATES = {
 }
 
 DATA_COLUMNS = {
-    'WestCascades': ['estimate', 'flickr', 'twitter', 'instag', 'wta', 'alltrails', 'onsite'],
+    'WestCascades': ['estimate', 'flickr', 'twitter', 'instag', 'wta', 'alltrails', 'reveal', 'onsite'],
     'WestCascades_MiddleFork': ['estimate', 'flickr', 'twitter', 'instag', 'wta', 'alltrails', 'onsite'],
     # 'OKW_WILD': ['flickr', 'twitter', 'instag', 'wta'],
     # 'OKW_GFA': ['flickr', 'twitter', 'instag', 'wta'],

--- a/trails-viz-api/trailsvizapi/config/app_config.py
+++ b/trails-viz-api/trailsvizapi/config/app_config.py
@@ -38,7 +38,7 @@ CENSUS_TRACT_STATES = {
 }
 
 DATA_COLUMNS = {
-    'WestCascades': ['estimate', 'flickr', 'twitter', 'instag', 'wta', 'alltrails', 'reveal', 'onsite'],
+    'WestCascades': ['estimate', 'flickr', 'twitter', 'wta', 'alltrails', 'reveal', 'onsite'],
     'WestCascades_MiddleFork': ['estimate', 'flickr', 'twitter', 'instag', 'wta', 'alltrails', 'onsite'],
     # 'OKW_WILD': ['flickr', 'twitter', 'instag', 'wta'],
     # 'OKW_GFA': ['flickr', 'twitter', 'instag', 'wta'],


### PR DESCRIPTION
Adds `reveal` and removes `instag` from the `westcascades` dashboard. Based off of the discussion in https://github.com/OutdoorRD/trails-viz-data/pull/64.