### PR TITLE
switch from hard-coded href to router-links for breadcrumb

### DIFF
--- a/trails-viz-app/src/components/Dashboard.vue
+++ b/trails-viz-app/src/components/Dashboard.vue
@@ -129,7 +129,7 @@
 
         this.breadcrumbItems.push({
           text: projectName,
-          href: '/dashboard/' + projectCode
+          to: { name: 'dashboard', params: { project: projectCode } }
         });
 
         this.trailName = 'All Sites in ' + projectName;


### PR DESCRIPTION
The breadcrumb had a hard-coded href which does not work after changing the router mode to 'hash' and appending the base route with '/trails-viz/'.

By switching over to router-links and route component names, the breadcrumb uses Vue's internal navigation and adjusts routing URL correctly based on what is defined in router.js.