### PR TITLE
Fix python setup in API CI/CD workflow

### DIFF
--- a/.github/workflows/api_CICD.yml
+++ b/.github/workflows/api_CICD.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.7'
+        python-version: '3.7.12'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/api_CICD.yml
+++ b/.github/workflows/api_CICD.yml
@@ -22,9 +22,9 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.7.12'
+        python-version: '3.7'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Manually install python `3.7.12` in workflow and required packages.