### PR TITLE
Checking dashboard chatbot dates 

### DIFF
--- a/trails-viz-app/src/store/constants.js
+++ b/trails-viz-app/src/store/constants.js
@@ -42,8 +42,8 @@ export const DATA_SOURCES = {
   // 'Okanogan-Wenatchee Wilderness (Archived)': [],
   // 'Okanogan-Wenatchee General Forest (Archived)': [],
   'Northern New Mexico': ['Flickr (2005 - 2019)'],
-  'King County Parks': ['Chatbot (2023 - 2024)', 'Reveal (2021 - 2024)'],
-  'US National Forests': ['Chatbot (2018 - 2024)', 'Flickr (2005 - 2019)'],
+  'King County Parks': ['Chatbot (2023-2024)', 'Reveal (2021 - 2024)'],
+  'US National Forests': [], //should not show Visitor Characteristics
   'Mount Baker-Snoqualmie Wilderness': ['Chatbot (2018 - 2024)', 'Flickr (2005 - 2019)'],
   'Mountain Loop': ['Chatbot (2018 - 2024)', 'Flickr (2005 - 2019)'],
   'South Mountain Loop': ['Chatbot (2018 - 2024)', 'Flickr (2005 - 2019)'],

--- a/trails-viz-app/src/store/constants.js
+++ b/trails-viz-app/src/store/constants.js
@@ -42,7 +42,7 @@ export const DATA_SOURCES = {
   // 'Okanogan-Wenatchee Wilderness (Archived)': [],
   // 'Okanogan-Wenatchee General Forest (Archived)': [],
   'Northern New Mexico': ['Flickr (2005 - 2019)'],
-  'King County Parks': ['Chatbot (2023-2024)', 'Reveal (2021 - 2024)'],
+  'King County Parks': ['Chatbot (2023 - 2024)', 'Reveal (2021 - 2024)'],
   'US National Forests': [], //should not show Visitor Characteristics
   'Mount Baker-Snoqualmie Wilderness': ['Chatbot (2018 - 2024)', 'Flickr (2005 - 2019)'],
   'Mountain Loop': ['Chatbot (2018 - 2024)', 'Flickr (2005 - 2019)'],


### PR DESCRIPTION
I looked over the date ranges, and the chatbot dates look right to me! And I assumed the Flickr date range was correct as well. The one edit I have here is removing chatbot/flickr data from the US National Forests dashboard. I actually have no idea what belongs here, I just noticed that we don't really have any tagged data for this project at this moment. Do we want viz-characteristics for this dashboard?

This is directed by this [issue](https://github.com/OutdoorRD/trails-viz-data/issues/77#issuecomment-2741242709)