### PR TITLE
patch site-level home locations bug

### DIFF
--- a/trails-viz-api/trailsvizapi/controller/home_locations.py
+++ b/trails-viz-api/trailsvizapi/controller/home_locations.py
@@ -8,7 +8,7 @@ from trailsvizapi.repository import home_locations
 def get_home_locations(siteid, source):
     year_start = request.args.get('year_start')
     year_end = request.args.get('year_end')
-    data = home_locations.get_home_locations(siteid, source, year_start, year_end, year_start, year_end)
+    data = home_locations.get_home_locations(siteid, source, year_start, year_end)
     return jsonify(data)
 
 


### PR DESCRIPTION
This PR patches a bug in the API serving site-level home location data.

The API throws a 500 internal server error when the user selected a specific site and views Home Locations. As a result, the Home Locations tab shows project level data even when a site is selected.

The bug was caused by accidentally including duplicate arguments when calling the `get_home_locations` method.

The patch is simply removing the duplicate arguments.
