### PR TITLE
Resolve "unauthorized" bug, add error handling in API for year_start and year_end parameters

### DIFF
--- a/trails-viz-api/trailsvizapi/controller/categorical_chatbot_data.py
+++ b/trails-viz-api/trailsvizapi/controller/categorical_chatbot_data.py
@@ -1,4 +1,4 @@
-from flask import request
+from flask import request, abort
 from trailsvizapi import app
 from trailsvizapi.repository import categorical_chatbot_data
 
@@ -7,6 +7,11 @@ from trailsvizapi.repository import categorical_chatbot_data
 def get_project_categorical_chatbot_data(project, characteristic):
     year_start = request.args.get('year_start')
     year_end = request.args.get('year_end')
+    try:
+        year_start = int(year_start)
+        year_end = int(year_end)
+    except ValueError:
+        abort(400, "Invalid year range")
     return categorical_chatbot_data.get_project_categorical_chatbot_data(project, characteristic, year_start, year_end)
 
 
@@ -14,4 +19,9 @@ def get_project_categorical_chatbot_data(project, characteristic):
 def get_categorical_chatbot_data(siteid, characteristic):
     year_start = request.args.get('year_start')
     year_end = request.args.get('year_end')
+    try:
+        year_start = int(year_start)
+        year_end = int(year_end)
+    except ValueError:
+        abort(400, "Invalid year range")
     return categorical_chatbot_data.get_categorical_chatbot_data(siteid, characteristic, year_start, year_end)

--- a/trails-viz-api/trailsvizapi/controller/chatbot_data.py
+++ b/trails-viz-api/trailsvizapi/controller/chatbot_data.py
@@ -1,4 +1,4 @@
-from flask import request
+from flask import request, abort
 from trailsvizapi import app
 from trailsvizapi.repository import chatbot_data
 
@@ -7,6 +7,11 @@ from trailsvizapi.repository import chatbot_data
 def get_project_chatbot_data(project, characteristic):
     year_start = request.args.get('year_start')
     year_end = request.args.get('year_end')
+    try:
+        year_start = int(year_start)
+        year_end = int(year_end)
+    except ValueError:
+        abort(400, "Invalid year range")
     return chatbot_data.get_project_chatbot_data(project, characteristic, year_start, year_end)
 
 
@@ -14,6 +19,11 @@ def get_project_chatbot_data(project, characteristic):
 def get_chatbot_data(siteid, characteristic):
     year_start = request.args.get('year_start')
     year_end = request.args.get('year_end')
+    try:
+        year_start = int(year_start)
+        year_end = int(year_end)
+    except ValueError:
+        abort(400, "Invalid year range")
     return chatbot_data.get_chatbot_data(siteid, characteristic, year_start, year_end)
 
 
@@ -21,6 +31,11 @@ def get_chatbot_data(siteid, characteristic):
 def get_project_chatbot_data_yearly_statistics(project, characteristic):
     year_start = request.args.get('year_start')
     year_end = request.args.get('year_end')
+    try:
+        year_start = int(year_start)
+        year_end = int(year_end)
+    except ValueError:
+        abort(400, "Invalid year range")
     return chatbot_data.get_project_chatbot_data_yearly_statistics(project, characteristic, year_start, year_end)
 
 
@@ -28,4 +43,9 @@ def get_project_chatbot_data_yearly_statistics(project, characteristic):
 def get_chatbot_data_yearly_statistics(siteid, characteristic):
     year_start = request.args.get('year_start')
     year_end = request.args.get('year_end')
+    try:
+        year_start = int(year_start)
+        year_end = int(year_end)
+    except ValueError:
+        abort(400, "Invalid year range")
     return chatbot_data.get_chatbot_data_yearly_statistics(siteid, characteristic, year_start, year_end)

--- a/trails-viz-api/trailsvizapi/controller/home_locations.py
+++ b/trails-viz-api/trailsvizapi/controller/home_locations.py
@@ -1,4 +1,4 @@
-from flask import jsonify, Response, request
+from flask import jsonify, Response, request, abort
 
 from trailsvizapi import app
 from trailsvizapi.repository import home_locations
@@ -8,6 +8,11 @@ from trailsvizapi.repository import home_locations
 def get_home_locations(siteid, source):
     year_start = request.args.get('year_start')
     year_end = request.args.get('year_end')
+    try:
+        year_start = int(year_start)
+        year_end = int(year_end)
+    except ValueError:
+        abort(400, "Invalid year range")
     data = home_locations.get_home_locations(siteid, source, year_start, year_end)
     return jsonify(data)
 
@@ -16,6 +21,11 @@ def get_home_locations(siteid, source):
 def get_home_locations_state(siteid, source):
     year_start = request.args.get('year_start')
     year_end = request.args.get('year_end')
+    try:
+        year_start = int(year_start)
+        year_end = int(year_end)
+    except ValueError:
+        abort(400, "Invalid year range")
     data = home_locations.get_home_locations_by_state(siteid, source, year_start, year_end)
     return Response(data.to_json(), mimetype='application/json')
 
@@ -24,6 +34,11 @@ def get_home_locations_state(siteid, source):
 def get_home_locations_county(siteid, state_code, source):
     year_start = request.args.get('year_start')
     year_end = request.args.get('year_end')
+    try:
+        year_start = int(year_start)
+        year_end = int(year_end)
+    except ValueError:
+        abort(400, "Invalid year range")
     data = home_locations.get_home_locations_by_county(siteid, source, state_code, year_start, year_end)
     return Response(data.to_json(), mimetype='application/json')
 
@@ -33,6 +48,11 @@ def get_home_locations_county(siteid, state_code, source):
 def get_home_locations_zcta(siteid, source, state_code, county_code):
     year_start = request.args.get('year_start')
     year_end = request.args.get('year_end')
+    try:
+        year_start = int(year_start)
+        year_end = int(year_end)
+    except ValueError:
+        abort(400, "Invalid year range")
     data = home_locations.get_home_locations_by_zcta(
             siteid, source, state_code, county_code, year_start, year_end)
     if data is None:
@@ -54,6 +74,11 @@ def get_home_locations_census_tract(siteid, source, state_code, county_code, zct
 def get_project_home_locations(project, source):
     year_start = request.args.get('year_start')
     year_end = request.args.get('year_end')
+    try:
+        year_start = int(year_start)
+        year_end = int(year_end)
+    except ValueError:
+        abort(400, "Invalid year range")
     data = home_locations.get_project_home_locations(project, source, year_start, year_end)
     return jsonify(data)
 
@@ -62,6 +87,11 @@ def get_project_home_locations(project, source):
 def get_project_home_locations_state(project, source):
     year_start = request.args.get('year_start')
     year_end = request.args.get('year_end')
+    try:
+        year_start = int(year_start)
+        year_end = int(year_end)
+    except ValueError:
+        abort(400, "Invalid year range")
     data = home_locations.get_project_home_locations_by_state(project, source, year_start, year_end)
     return Response(data.to_json(), mimetype='application/json')
 
@@ -70,6 +100,11 @@ def get_project_home_locations_state(project, source):
 def get_home_project_locations_county(project, state_code, source):
     year_start = request.args.get('year_start')
     year_end = request.args.get('year_end')
+    try:
+        year_start = int(year_start)
+        year_end = int(year_end)
+    except ValueError:
+        abort(400, "Invalid year range")
     data = home_locations.get_project_home_locations_by_county(project, source, state_code, year_start, year_end)
     return Response(data.to_json(), mimetype='application/json')
 
@@ -79,6 +114,11 @@ def get_home_project_locations_county(project, state_code, source):
 def get_project_home_locations_zcta(project, source, state_code, county_code):
     year_start = request.args.get('year_start')
     year_end = request.args.get('year_end')
+    try:
+        year_start = int(year_start)
+        year_end = int(year_end)
+    except ValueError:
+        abort(400, "Invalid year range")
     data = home_locations.get_project_home_locations_by_zcta(
             project, source, state_code, county_code, year_start, year_end)
     if data is None:
@@ -101,6 +141,11 @@ def get_project_home_locations_census_tract(project, source, state_code, county_
 def get_home_locations_demographics(siteid, source):
     year_start = request.args.get('year_start')
     year_end = request.args.get('year_end')
+    try:
+        year_start = int(year_start)
+        year_end = int(year_end)
+    except ValueError:
+        abort(400, "Invalid year range")
     data = home_locations.get_demographic_summary(siteid, source, year_start, year_end)
     return Response(data.to_json(orient='records'), mimetype='application/json')
 
@@ -109,5 +154,10 @@ def get_home_locations_demographics(siteid, source):
 def get_project_home_locations_demographics(project, source):
     year_start = request.args.get('year_start')
     year_end = request.args.get('year_end')
+    try:
+        year_start = int(year_start)
+        year_end = int(year_end)
+    except ValueError:
+        abort(400, "Invalid year range")
     data = home_locations.get_project_demographic_summary(project, source, year_start, year_end)
     return Response(data.to_json(orient='records'), mimetype='application/json')

--- a/trails-viz-app/src/components/Dashboard.vue
+++ b/trails-viz-app/src/components/Dashboard.vue
@@ -149,7 +149,7 @@ import HomeLocationsMap from "../components/HomeLocationsMap";
 import InfoViewer from "../components/InfoViewer";
 import DemographicsSummary from "../components/DemographicsSummary";
 import PartyCharacteristics from "../components/PartyCharacteristics";
-import InfoSource from "../components/InfoSource.vue";
+import InfoSource from "../components/InfoSource";
 
 import { VIZ_MODES, DATA_SOURCES } from "../store/constants";
 import { EventBus } from "../event-bus";

--- a/trails-viz-app/src/components/InfoSource.vue
+++ b/trails-viz-app/src/components/InfoSource.vue
@@ -109,9 +109,6 @@ export default {
           this.loading = false;
         });
     }
-  },
-  mounted() {
-    this.renderInfoSource();
   }
 };
 </script>

--- a/trails-viz-app/src/components/PartyCharacteristics.vue
+++ b/trails-viz-app/src/components/PartyCharacteristics.vue
@@ -196,11 +196,6 @@ export default {
       this.projectName = this.$store.getters.getSelectedProjectName;
       this.projectCode = this.$store.getters.getSelectedProjectCode;
       this.siteid = this.$store.getters.getSelectedSite['siteid'];
-
-      // If projectCode or siteid not ready, skip
-      if (!this.projectCode && this.vizMode === VIZ_MODES.PROJECT) return;
-      if (!this.siteid && this.vizMode !== VIZ_MODES.PROJECT) return;
-
       Promise.all([
         this.fetchAllBarData(),
         this.fetchAllTimeSeriesData()
@@ -581,11 +576,7 @@ export default {
     yearRange() {
       this.renderPartyCharacteristics();
     }
-  },
-
-  mounted() {
-    this.renderPartyCharacteristics();
-  },
+  }
 };
 </script>
 


### PR DESCRIPTION
Bug: Unauthorized alert pops up even after user has logged in. Alert pops up when user first accesses a project. This bug is caused by https://github.com/OutdoorRD/trails-viz/pull/282.
![image](https://github.com/user-attachments/assets/0757a8e1-8c5e-4890-8c4b-4d4575114352)
Solution: Remove premature mounting from impacted visitor characteristic components.

Bug: API internal server error occurs when `year_start` and `year_end` aren't properly defined (may occur when first accessing a project with chatbot data)
Solution: Add a try/except block to catch `year_start` and `year_end` value errors, and returns a 400 status code if exception occurs.