### PR TITLE
Update year_start and year_end exception handling in API

### DIFF
--- a/trails-viz-api/trailsvizapi/controller/categorical_chatbot_data.py
+++ b/trails-viz-api/trailsvizapi/controller/categorical_chatbot_data.py
@@ -10,8 +10,8 @@ def get_project_categorical_chatbot_data(project, characteristic):
     try:
         year_start = int(year_start)
         year_end = int(year_end)
-    except ValueError:
-        abort(400, "Invalid year range")
+    except (ValueError, TypeError):
+        abort(400, "Must provide integer year_start and year_end")
     return categorical_chatbot_data.get_project_categorical_chatbot_data(project, characteristic, year_start, year_end)
 
 
@@ -22,6 +22,6 @@ def get_categorical_chatbot_data(siteid, characteristic):
     try:
         year_start = int(year_start)
         year_end = int(year_end)
-    except ValueError:
-        abort(400, "Invalid year range")
+    except (ValueError, TypeError):
+        abort(400, "Must provide integer year_start and year_end")
     return categorical_chatbot_data.get_categorical_chatbot_data(siteid, characteristic, year_start, year_end)

--- a/trails-viz-api/trailsvizapi/controller/chatbot_data.py
+++ b/trails-viz-api/trailsvizapi/controller/chatbot_data.py
@@ -10,8 +10,8 @@ def get_project_chatbot_data(project, characteristic):
     try:
         year_start = int(year_start)
         year_end = int(year_end)
-    except ValueError:
-        abort(400, "Invalid year range")
+    except (ValueError, TypeError):
+        abort(400, "Must provide integer year_start and year_end")
     return chatbot_data.get_project_chatbot_data(project, characteristic, year_start, year_end)
 
 
@@ -22,8 +22,8 @@ def get_chatbot_data(siteid, characteristic):
     try:
         year_start = int(year_start)
         year_end = int(year_end)
-    except ValueError:
-        abort(400, "Invalid year range")
+    except (ValueError, TypeError):
+        abort(400, "Must provide integer year_start and year_end")
     return chatbot_data.get_chatbot_data(siteid, characteristic, year_start, year_end)
 
 
@@ -34,8 +34,8 @@ def get_project_chatbot_data_yearly_statistics(project, characteristic):
     try:
         year_start = int(year_start)
         year_end = int(year_end)
-    except ValueError:
-        abort(400, "Invalid year range")
+    except (ValueError, TypeError):
+        abort(400, "Must provide integer year_start and year_end")
     return chatbot_data.get_project_chatbot_data_yearly_statistics(project, characteristic, year_start, year_end)
 
 
@@ -46,6 +46,6 @@ def get_chatbot_data_yearly_statistics(siteid, characteristic):
     try:
         year_start = int(year_start)
         year_end = int(year_end)
-    except ValueError:
-        abort(400, "Invalid year range")
+    except (ValueError, TypeError):
+        abort(400, "Must provide integer year_start and year_end")
     return chatbot_data.get_chatbot_data_yearly_statistics(siteid, characteristic, year_start, year_end)

--- a/trails-viz-api/trailsvizapi/controller/home_locations.py
+++ b/trails-viz-api/trailsvizapi/controller/home_locations.py
@@ -11,8 +11,8 @@ def get_home_locations(siteid, source):
     try:
         year_start = int(year_start)
         year_end = int(year_end)
-    except ValueError:
-        abort(400, "Invalid year range")
+    except (ValueError, TypeError):
+        abort(400, "Must provide integer year_start and year_end")
     data = home_locations.get_home_locations(siteid, source, year_start, year_end)
     return jsonify(data)
 
@@ -24,8 +24,8 @@ def get_home_locations_state(siteid, source):
     try:
         year_start = int(year_start)
         year_end = int(year_end)
-    except ValueError:
-        abort(400, "Invalid year range")
+    except (ValueError, TypeError):
+        abort(400, "Must provide integer year_start and year_end")
     data = home_locations.get_home_locations_by_state(siteid, source, year_start, year_end)
     return Response(data.to_json(), mimetype='application/json')
 
@@ -37,8 +37,8 @@ def get_home_locations_county(siteid, state_code, source):
     try:
         year_start = int(year_start)
         year_end = int(year_end)
-    except ValueError:
-        abort(400, "Invalid year range")
+    except (ValueError, TypeError):
+        abort(400, "Must provide integer year_start and year_end")
     data = home_locations.get_home_locations_by_county(siteid, source, state_code, year_start, year_end)
     return Response(data.to_json(), mimetype='application/json')
 
@@ -51,8 +51,8 @@ def get_home_locations_zcta(siteid, source, state_code, county_code):
     try:
         year_start = int(year_start)
         year_end = int(year_end)
-    except ValueError:
-        abort(400, "Invalid year range")
+    except (ValueError, TypeError):
+        abort(400, "Must provide integer year_start and year_end")
     data = home_locations.get_home_locations_by_zcta(
             siteid, source, state_code, county_code, year_start, year_end)
     if data is None:
@@ -77,8 +77,8 @@ def get_project_home_locations(project, source):
     try:
         year_start = int(year_start)
         year_end = int(year_end)
-    except ValueError:
-        abort(400, "Invalid year range")
+    except (ValueError, TypeError):
+        abort(400, "Must provide integer year_start and year_end")
     data = home_locations.get_project_home_locations(project, source, year_start, year_end)
     return jsonify(data)
 
@@ -90,8 +90,8 @@ def get_project_home_locations_state(project, source):
     try:
         year_start = int(year_start)
         year_end = int(year_end)
-    except ValueError:
-        abort(400, "Invalid year range")
+    except (ValueError, TypeError):
+        abort(400, "Must provide integer year_start and year_end")
     data = home_locations.get_project_home_locations_by_state(project, source, year_start, year_end)
     return Response(data.to_json(), mimetype='application/json')
 
@@ -103,8 +103,8 @@ def get_home_project_locations_county(project, state_code, source):
     try:
         year_start = int(year_start)
         year_end = int(year_end)
-    except ValueError:
-        abort(400, "Invalid year range")
+    except (ValueError, TypeError):
+        abort(400, "Must provide integer year_start and year_end")
     data = home_locations.get_project_home_locations_by_county(project, source, state_code, year_start, year_end)
     return Response(data.to_json(), mimetype='application/json')
 
@@ -117,8 +117,8 @@ def get_project_home_locations_zcta(project, source, state_code, county_code):
     try:
         year_start = int(year_start)
         year_end = int(year_end)
-    except ValueError:
-        abort(400, "Invalid year range")
+    except (ValueError, TypeError):
+        abort(400, "Must provide integer year_start and year_end")
     data = home_locations.get_project_home_locations_by_zcta(
             project, source, state_code, county_code, year_start, year_end)
     if data is None:
@@ -144,8 +144,8 @@ def get_home_locations_demographics(siteid, source):
     try:
         year_start = int(year_start)
         year_end = int(year_end)
-    except ValueError:
-        abort(400, "Invalid year range")
+    except (ValueError, TypeError):
+        abort(400, "Must provide integer year_start and year_end")
     data = home_locations.get_demographic_summary(siteid, source, year_start, year_end)
     return Response(data.to_json(orient='records'), mimetype='application/json')
 
@@ -157,7 +157,7 @@ def get_project_home_locations_demographics(project, source):
     try:
         year_start = int(year_start)
         year_end = int(year_end)
-    except ValueError:
-        abort(400, "Invalid year range")
+    except (ValueError, TypeError):
+        abort(400, "Must provide integer year_start and year_end")
     data = home_locations.get_project_demographic_summary(project, source, year_start, year_end)
     return Response(data.to_json(orient='records'), mimetype='application/json')


### PR DESCRIPTION
API throws an internal server error when `year_start` and `year_end` query params aren't provided.

This PR makes the API throw a 400 status code with a clear message when the necessary query params aren't provided.