### PR TITLE
Fix "unauthorized" bug for projects without visitor characteristics

### DIFF
--- a/trails-viz-app/src/components/Dashboard.vue
+++ b/trails-viz-app/src/components/Dashboard.vue
@@ -276,11 +276,14 @@ export default {
           self.$refs["home-locations"].renderTreeMap();
           self.$refs["home-locations-map"].renderHomeLocationsMap();
           self.$refs["project-info"].renderInfo("project");
-          self.$refs["visitation-info"].renderInfo("visitation");
-          self.$refs["home-locations-info"].renderInfo("homeLocations");
           self.$refs["demographics-summary"].renderDemographicsSummary();
-          self.$refs["party-characteristics"].renderPartyCharacteristics();
-          self.$refs["info-source"].renderInfoSource();
+          if (self.$refs["party-characteristics"]) {
+            self.$refs["party-characteristics"].renderPartyCharacteristics()
+          }
+          if (self.$refs["info-source"]) {
+            self.$refs["info-source"].renderInfoSource();
+          }
+
         });
     },
     renderSiteLevelPlots: function() {

--- a/trails-viz-app/src/components/DemographicsSummary.vue
+++ b/trails-viz-app/src/components/DemographicsSummary.vue
@@ -100,7 +100,10 @@
         self.projectName = self.$store.getters.getSelectedProjectName;
         self.projectCode = self.$store.getters.getSelectedProjectCode;
         self.siteid = self.$store.getters.getSelectedSite['siteid'];
-
+        if (!this.selectedSource) {
+          self.loading = false;
+          return;
+        }
         let url;
         if (vizMode === VIZ_MODES.PROJECT) {
           url = self.$apiEndpoint + '/projects/' + self.projectCode + '/source/' + this.selectedSource + '/homeLocationsDemographics';

--- a/trails-viz-app/src/components/HomeLocations.vue
+++ b/trails-viz-app/src/components/HomeLocations.vue
@@ -149,6 +149,10 @@
         self.projectCode = self.$store.getters.getSelectedProjectCode;
         self.siteid = self.$store.getters.getSelectedSite['siteid'];
 
+        if (!this.selectedSource) {
+          self.loading = false;
+          return;
+        }
         let homeLocationsUrl;
         if (self.$store.getters.getVizMode === VIZ_MODES.PROJECT) {
           homeLocationsUrl = this.$apiEndpoint + '/projects/' + self.projectCode + '/source/' + this.selectedSource + '/homeLocations'

--- a/trails-viz-app/src/components/HomeLocationsMap.vue
+++ b/trails-viz-app/src/components/HomeLocationsMap.vue
@@ -125,6 +125,10 @@
         self.loading = true;
         let url;
         self.level = 'state';
+        if (!this.selectedSource) {
+          self.loading = false;
+          return;
+        }
         if (self.$store.getters.getVizMode === VIZ_MODES.PROJECT) {
           self.projectCode = self.$store.getters.getSelectedProjectCode;
           url = self.$apiEndpoint + '/projects/' + self.projectCode + '/source/' + this.selectedSource + '/homeLocationsState';


### PR DESCRIPTION
For projects without the visitor characteristics tab, there are no "data sources". As a result, a faulty API will be called:
`https://trailtrends.outdoorrd.org/api/projects/BT/source//homeLocationsDemographics`

This results in a 403 forbidden error, triggering the "Unauthorized" popup. This popup appears on projects like Bridger Teton that don't have "data sources"/visitor characteristics tab (despite the user being logged in).

A patch is returning early and skipping the effected API calls if `selectedSource` is empty.