### PR TITLE
Keep missing modeled values out of the time series instead of drawing them as zeros

### DIFF
--- a/trails-viz-app/src/components/TimeSeries.vue
+++ b/trails-viz-app/src/components/TimeSeries.vue
@@ -43,6 +43,12 @@
     return s;
   };
 
+  // The api sends a data point with no value as null, so keep it null instead
+  // of letting Math.round turn it into a 0 that gets plotted as a real value.
+  function roundOrNull(value) {
+    return value === null || value === undefined ? value : Math.round(value);
+  }
+
   export default {
     name: "TimeSeries",
     data: function() {
@@ -100,7 +106,7 @@
 
         monthlyVisitation.forEach(x => {
           monthlyDates.push(x.year + '-' + x.month + '-1');
-          monthlyModelled.push(Math.round(x.estimate, 2));
+          monthlyModelled.push(roundOrNull(x.estimate));
           monthlyOnsite.push(x.onsite);
           monthlyFlickr.push(x.flickr);
           monthlyInstag.push(x.instag);
@@ -170,7 +176,7 @@
 
         weeklyVisitation.forEach(x => {
           weeklyDates.push(x.weekstart);
-          weeklyModelled.push(Math.round(x.estimate, 2));
+          weeklyModelled.push(roundOrNull(x.estimate));
           weeklyOnsite.push(x.onsite);
           weeklyFlickr.push(x.flickr);
           weeklyInstag.push(x.instag);


### PR DESCRIPTION
This PR proposes keeping missing modeled values out of the time series plots instead of drawing them as zeros (fixes #127). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/346. You can sign in with your GitHub ID to claim ownership of the project.

## What was wrong

In `trails-viz-app/src/components/TimeSeries.vue` every visitation series is pushed onto its c3 column exactly as the api sent it — `monthlyOnsite.push(x.onsite)`, `monthlyFlickr.push(x.flickr)`, and so on — with one exception: the modeled series went through `monthlyModelled.push(Math.round(x.estimate, 2))`. `/api/sites/<siteid>/monthlyVisitation` serialises its dataframe with `to_json()`, which writes a missing value as `null`, and `Math.round(null)` is `0`. So a month whose `jjmm` cell is empty reached c3 as a real zero and was drawn as a real data point, while the social media and on-site series carrying the same missing value reached c3 as `null` and were drawn as a gap — c3 leaves `line_connectNull` at false and filters points with `line.defined(d => d.value != null)`. `_prepareWeeklyData` had the identical line. That is the asymmetry #127 describes: empty cells work for the social media and on-site data, and the modeled results still come out as zeros.

### Reproducing it on master

Run this from `trails-viz-app/` on a clean master checkout (after `npm install`). It loads the real component and asks `_prepareMonthlyData` for the columns it would hand to `c3.generate()` for one month whose csv cells are empty:

```sh
node -e '
const fs = require("fs"), { parseComponent } = require("vue-template-compiler");
const src = "const VIZ_MODES = {};" + parseComponent(fs.readFileSync("src/components/TimeSeries.vue", "utf8")).script.content
  .replace(/^\s*import .*$/gm, "").replace("export default", "module.exports =");
const m = { exports: {} }; new Function("module", "exports", src)(m, m.exports);
const store = { getters: { getSelectedProjectDataSources: ["estimate", "onsite", "flickr"], getVizMode: "SITE" } };
const rows = [{ year: 2023, month: 7, estimate: null, onsite: null, flickr: null }];
for (const col of m.exports.methods._prepareMonthlyData.call({ $store: store }, "Test Site", rows))
  if (col[0] !== "date") console.log(col[0] + ": " + JSON.stringify(col[1]));
'
```

master gives the modeled series a zero and the others a gap:

```
Test Site - Modelled: 0
Test Site - On Site: null
Test Site - Flickr: null
```

On this branch the same command gives:

```
Test Site - Modelled: null
Test Site - On Site: null
Test Site - Flickr: null
```

### The change

A `roundOrNull()` helper passes `null` and `undefined` straight through and rounds everything else, and the two modeled `push` calls now use it. Values that are present round exactly as before — `Math.round` never read that second argument, so dropping it changes nothing — and a genuine `0` in the data still plots as `0`. Only missing values move, from a drawn zero to a gap. Nothing unfamiliar reaches c3 either: these same plots already hand it `null` from the other nine series, so this simply puts the modeled series on the path the rest of the chart has always used. The csv from **Download Data** follows along, leaving the cell empty where it used to write `0`.

### How it was verified

There is no test runner in the repo, so I exercised the real methods directly and ran your own checks around them: `npm run lint` and `npm run build` in `trails-viz-app` produce identical, clean output before and after the change. Beyond the reproduction above, I asserted against `_prepareMonthlyData`, `_prepareWeeklyData` and `convertToCSV` that 1234.4 and 1234.6 still round to 1234 and 1235; that a genuine `0` stays `0`; that `null` stays `null`; that an absent `estimate` key now yields `undefined` instead of the `NaN` master produced; that the date, on-site and social media columns are unchanged; that compare mode still emits both sites' modeled series with the gap preserved on each; and that the csv export writes `2023-4-1,,,` where master wrote `2023-4-1,0,,`. Five of those assertions fail on master and pass here, and the rounding, zero and date assertions are controls that pass on both.

Two notes for review. #297 is open against these same two lines — it renames `Modelled` to `Modeled` and adds a Cuebiq series — so whichever lands second wants a small rebase; the change is one call per line, `roundOrNull(x.estimate)` in place of `Math.round(x.estimate, 2)`. And I left `BarGraph.vue` alone, where the annual bar chart rounds every series the same way: #127 is about the time series plots, and whether a bar should vanish or sit at zero is a judgement about your data rather than a defect. Happy to extend it there if you would like.

## How this was managed

This work was tracked on a board built from this repository's own issues and pull requests — 272 stories and 9 labels — where #127 arrived as [Improve time series plots to not display NAs or empty cells](https://eastagiletracker.com/projects/346/stories/215682), the story this change was written against. The board itself is at https://eastagiletracker.com/projects/346.

![board](https://raw.githubusercontent.com/eastagiletracker/trails-viz/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
